### PR TITLE
[FIX 🛠️] Enhancements to Contact Information Footer (Email and Phone Number)

### DIFF
--- a/src/sections/Cart.jsx
+++ b/src/sections/Cart.jsx
@@ -47,7 +47,7 @@ const Cart = () => {
     <>
       <Menu />
       <section className="py-12 sm:py-16 lg:py-20 mb-5">
-        <div className="mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto pt-16 px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-center">
             <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-300">Your Cart</h1>
           </div>

--- a/src/sections/Footer.jsx
+++ b/src/sections/Footer.jsx
@@ -38,7 +38,7 @@ const Footer = () => {
                 <ul className="relative">
                   {section.links.map((link) => (
                     <li key={link.name} className="mt-3 text-white-400 font-montserrat text-base leading-normal">
-                      <a className="hoverUnderline" href="">
+                      <a className="hoverUnderline" href={link.link}>
                         {link.name}
                       </a>
                     </li>


### PR DESCRIPTION
# Issue #147 📐

- I [leonyangela](https://github.com/leonyangela) have worked for #147 

## Guidelines 🔐

I accept the fact that I have followed the guidelines and have not copied the codes from around the internet

- [x] **Contribution Guidelines**
- [x] **Code of Conduct**

## Issue to be closed 🛅

- My pull request closes #147 

## Screenshots 📷

Here are the pictures of changes that I have made 🔽
Description: When in the footer section, clicking on "[customer@nike.com](mailto:customer@nike.com)" or the telephone number will open the corresponding app.

<img width="960" alt="image" src="https://github.com/warmachine028/nike/assets/38250310/a55dbef3-6287-4465-9329-536200bd8303">

<img width="960" alt="image" src="https://github.com/warmachine028/nike/assets/38250310/061ec1e4-03b0-4aef-aa97-d3a48a413f18">
  
<!-- Please refer to previous closed issues for better understanding of filling this template -->  
  
---
